### PR TITLE
Integrating servers made easier with HTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ coverage/
 
 # Package files
 *.tgz
+test-battle.sh

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The server implements the MCP protocol with the following tools:
 ### Part 1: Basic Integration (30 minutes)
 
 1. Configure the MCP server in your chosen client (Claude Desktop or ChatGPT-compatible) for testing purposes. 
-Make sure that you create an actual server that stdio for interacting with the MCP server.
+Make sure you run an actual server that uses stdio to interact with the MCP server.
 2. Test basic functionality:
    - List all available Pokemon
    - Generate a random Pokemon

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ The server implements the MCP protocol with the following tools:
 
 ### Part 1: Basic Integration (30 minutes)
 
-1. Configure the MCP server in your chosen client (Claude Desktop or ChatGPT-compatible)
+1. Configure the MCP server in your chosen client (Claude Desktop or ChatGPT-compatible) for testing purposes. 
+Make sure that you create an actual server that stdio for interacting with the MCP server.
 2. Test basic functionality:
    - List all available Pokemon
    - Generate a random Pokemon

--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,15 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
   Tool,
+  isInitializeRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import express, { Request, Response } from "express";
 import cors from "cors";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { randomUUID } from "node:crypto";
 
 /**
  * Pokemon MCP Server
@@ -19,8 +21,15 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
  * Architecture:
  *   - POKEMON_DB / MOVES_DB: Static data for species and moves
  *   - TYPE_EFFECTIVENESS: Type chart (attacking → defending → multiplier)
- *   - BattleState: Singleton state for the active battle
+ *   - BattleState: Singleton state for the active battle (shared across transports)
+ *   - createServer(): Factory that produces a configured MCP Server instance
  *   - Tool handlers: MCP tool implementations (list, get, battle, attack, etc.)
+ *
+ * Transports (run simultaneously):
+ *   - Stdio: For local MCP clients (Claude Desktop). One Server instance.
+ *   - Streamable HTTP: For remote/web clients. One Server instance per session,
+ *     served via Express on PORT (default 3000). Uses the MCP Streamable HTTP
+ *     protocol (POST/GET/DELETE on /mcp) with session IDs in headers.
  *
  * Key mechanics:
  *   - Damage = ((2*Level+10)/250) * (Atk/Def) * Power + 2, × STAB × Type × Random
@@ -102,6 +111,7 @@ interface BattlePokemon extends Pokemon {
   status: null;
 }
 
+/** Tracks the state of an ongoing battle between two Pokemon. */
 interface BattleState {
   active: boolean;
   pokemon1: BattlePokemon;
@@ -110,6 +120,10 @@ interface BattleState {
   currentTurn: "pokemon1" | "pokemon2";
 }
 
+/**
+ * Singleton battle state, shared across all transports (stdio + HTTP sessions).
+ * Only one battle can be active at a time regardless of which client started it.
+ */
 let currentBattle: BattleState | null = null;
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -246,12 +260,12 @@ function calculateDamage(
 // MCP Server & Tool Handlers
 // ═══════════════════════════════════════════════════════════════════════════
 
-const server = new Server({
-  name: "pokemon-server",
-  version: "1.0.0",
-});
-
-// Available tools metadata
+/**
+ * MCP tool definitions exposed to clients via tools/list.
+ * Each tool has a name, description, and JSON Schema for its input.
+ * The actual implementations live in the CallToolRequestSchema handler
+ * inside createServer().
+ */
 const TOOLS: Tool[] = [
   {
     name: "get_random_pokemon",
@@ -325,16 +339,36 @@ const TOOLS: Tool[] = [
   },
 ];
 
-// List tools
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: TOOLS,
-}));
+/**
+ * Factory: creates a fully configured MCP Server with all tool handlers.
+ *
+ * Why a factory? A single MCP Server can only bind to one transport at a time.
+ * We need separate instances for:
+ *   - The stdio transport (one long-lived instance)
+ *   - Each HTTP session (one instance per connecting client)
+ *
+ * All instances share the same module-level `currentBattle` state, so a battle
+ * started over stdio is visible to HTTP clients and vice versa.
+ */
+function createServer(): Server {
+  const server = new Server({
+    name: "pokemon-server",
+    version: "1.0.0",
+  }, {
+    capabilities: { tools: {} },
+  });
 
-// Call tools
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  // List tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: TOOLS,
+  }));
+
+  // Handle tool invocations — dispatches by tool name to the appropriate handler
+  server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
   const { name, arguments: args } = request.params;
 
   switch (name) {
+    // Pick a random species, scale to given (or random) level, assign random moves
     case "get_random_pokemon": {
       const levelArg = typeof args?.level === "number" ? args.level : undefined;
       const species = POKEMON_DB[Math.floor(Math.random() * POKEMON_DB.length)];
@@ -355,6 +389,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       };
     }
 
+    // Look up a specific species by name (case-insensitive), scale to level
     case "get_pokemon_by_name": {
       if (!args || typeof args.name !== "string") {
         throw new Error("`name` must be provided and be a string");
@@ -385,6 +420,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       };
     }
 
+    // Return a summary of every species in POKEMON_DB
     case "list_all_pokemon": {
       const lines = POKEMON_DB.map(p =>
         `${p.name} [${p.types.join("/")}] — HP${p.baseStats.hp} ATK${p.baseStats.attack} DEF${p.baseStats.defense} SPD${p.baseStats.speed}`
@@ -394,6 +430,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       };
     }
 
+    // Initialize a new battle between two named Pokemon (replaces any active battle)
     case "start_battle": {
       const { pokemon1_name, pokemon1_level, pokemon2_name, pokemon2_level } = args ?? {};
       if (typeof pokemon1_name !== "string" || typeof pokemon2_name !== "string") {
@@ -440,6 +477,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       };
     }
 
+    // Execute one attack: validate turn order, check accuracy, calculate damage, update HP
     case "attack": {
       if (!currentBattle?.active) {
         throw new Error("No active battle. Use `start_battle` first.");
@@ -530,6 +568,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: "text", text }] };
     }
 
+    // Return current HP and turn info for the active battle
     case "get_battle_status": {
       if (!currentBattle) {
         return { content: [{ type: "text", text: "No active battle." }] };
@@ -544,6 +583,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: "text", text: lines.join("\n") }] };
     }
 
+    // Query the type chart: one matchup (atk vs def) or full chart for an attacking type
     case "get_type_effectiveness": {
       if (typeof args?.attacking_type !== "string") {
         throw new Error("`attacking_type` is required");
@@ -591,60 +631,103 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     default:
       throw new Error(`Tool "${name}" not recognized`);
   }
-});
+  });
 
-// Boot server
+  return server;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Server Bootstrap
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Start both transports simultaneously:
+ *
+ *  1. **Stdio** — for local MCP clients like Claude Desktop that launch this
+ *     process and communicate over stdin/stdout. Single long-lived Server.
+ *
+ *  2. **Streamable HTTP** — for remote/web MCP clients that connect over the
+ *     network. Each client session gets its own Server + Transport pair.
+ *     The MCP Streamable HTTP protocol uses a single `/mcp` endpoint with
+ *     three HTTP methods:
+ *       - POST: client → server JSON-RPC messages
+ *       - GET:  server → client SSE notification stream
+ *       - DELETE: session termination
+ *     Sessions are identified by the `Mcp-Session-Id` header.
+ */
 async function main() {
-  // Use stdio transport for MCP client compatibility (Claude Desktop)
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  // ── Stdio Transport ────────────────────────────────────────────────────
+  // Used by Claude Desktop and other local MCP clients that spawn this process.
+  const stdioServer = createServer();
+  const stdioTransport = new StdioServerTransport();
+  await stdioServer.connect(stdioTransport);
 
-  // Optional: Uncomment below for HTTP/SSE transport instead
-  /*
+  // ── Streamable HTTP Transport ──────────────────────────────────────────
+  // Exposes the same MCP tools over HTTP for remote clients.
   const app = express();
   const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 
-  // Store active transports keyed by session
-  const transports: Map<string, SSEServerTransport> = new Map();
+  // Active HTTP sessions keyed by session ID (assigned on initialize)
+  const httpTransports: Record<string, StreamableHTTPServerTransport> = {};
 
   app.use(cors());
   app.use(express.json());
 
-  app.get('/', (req: Request, res: Response) => {
+  // Health-check / discovery endpoint
+  app.get("/", (_req: Request, res: Response) => {
     res.json({
-      status: 'Pokemon MCP Server is running!',
-      version: '1.0.0',
+      status: "Pokemon MCP Server is running!",
+      version: "1.0.0",
       endpoints: {
-        health: 'GET /',
-        mcp: 'GET,POST /mcp'
-      }
+        health: "GET /",
+        mcp: "POST,GET,DELETE /mcp",
+      },
     });
   });
 
-  // GET /mcp - opens the SSE stream
-  app.get("/mcp", async (req: Request, res: Response) => {
-    const transport = new SSEServerTransport("/mcp", res);
-    transports.set(transport.sessionId, transport);
-    await server.connect(transport);
-  });
-
-  // POST /mcp - receives messages from the client
+  // POST /mcp — handles all client-to-server JSON-RPC messages.
+  // On the first request (an "initialize" message with no session ID), a new
+  // session is created. Subsequent requests must include the Mcp-Session-Id header.
   app.post("/mcp", async (req: Request, res: Response) => {
-    const sessionId = req.query.sessionId as string;
-    const transport = transports.get(sessionId);
-    if (transport) {
-      await transport.handlePostMessage(req, res);
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+    if (sessionId && httpTransports[sessionId]) {
+      // Route to existing session
+      await httpTransports[sessionId].handleRequest(req, res, req.body);
+    } else if (!sessionId && isInitializeRequest(req.body)) {
+      // First contact — create a new session with its own Server + Transport
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          httpTransports[id] = transport;
+        },
+      });
+      const httpServer = createServer();
+      await httpServer.connect(transport);
+      await transport.handleRequest(req, res, req.body);
     } else {
-      res.status(400).send("Unknown session");
+      res.status(400).json({ error: "Invalid or missing session ID" });
     }
   });
 
-  app.listen(PORT, '0.0.0.0', () => {
-    console.error(`🚀 Pokemon MCP Server running on http://0.0.0.0:${PORT}`);
-    console.error(`🔗 MCP endpoint: http://0.0.0.0:${PORT}/mcp`);
-    console.error(`📡 Ready for client connections!`);
+  // GET /mcp — opens an SSE stream for server-initiated notifications.
+  // DELETE /mcp — tears down the session and cleans up resources.
+  // Both require a valid Mcp-Session-Id header.
+  const handleSessionRequest = async (req: Request, res: Response) => {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+    if (!sessionId || !httpTransports[sessionId]) {
+      res.status(400).json({ error: "Invalid or missing session ID" });
+      return;
+    }
+    await httpTransports[sessionId].handleRequest(req, res);
+  };
+
+  app.get("/mcp", handleSessionRequest);
+  app.delete("/mcp", handleSessionRequest);
+
+  app.listen(PORT, "0.0.0.0", () => {
+    console.error(`Pokemon MCP Server HTTP endpoint: http://0.0.0.0:${PORT}/mcp`);
   });
-  */
 }
 
 main().catch(err => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^0.4.0",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "cors": "^2.8.6",
         "express": "^5.1.0"
       },
@@ -437,6 +437,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -463,13 +474,42 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.4.0.tgz",
-      "integrity": "sha512-79gx8xh4o9YzdbtqMukOe5WKzvEZpvBA1x8PAgJWL7J5k06+vJx8NK2kWzOazPgqnfDego7cNEO8tjai/nOPAA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -629,6 +669,37 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -636,22 +707,26 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bytes": {
@@ -746,10 +821,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -885,18 +973,38 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -925,6 +1033,43 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
@@ -1060,36 +1205,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
+      "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1103,6 +1272,29 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1215,12 +1407,28 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1236,9 +1444,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -1258,17 +1466,25 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1359,6 +1575,25 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -1428,9 +1663,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1559,6 +1794,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1579,6 +1828,14 @@
       "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^0.4.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "cors": "^2.8.6",
     "express": "^5.1.0"
   },


### PR DESCRIPTION
This pull request refactors the Pokemon MCP server to support both stdio and HTTP transports simultaneously, allowing local and remote clients to interact with the server at the same time. It introduces a factory function for creating server instances, ensures that battle state is shared across all transports, and updates the HTTP implementation to use the new Streamable HTTP protocol with proper session management. The code is also reorganized for clarity, and the MCP SDK is updated to a newer version.

**Multi-transport support and architecture changes:**

- Added simultaneous support for both stdio (for local clients like Claude Desktop) and Streamable HTTP (for remote/web clients), each with their own `Server` instance but sharing a singleton battle state. The HTTP implementation now uses the MCP Streamable HTTP protocol, handling session management with unique session IDs and a single `/mcp` endpoint for POST, GET, and DELETE requests. [[1]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L22-R33) [[2]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L596-L647)

- Introduced a `createServer()` factory function to generate new, fully configured MCP server instances for each transport/session, ensuring proper separation of stateful transport connections while sharing the battle state.

**Battle state and tool handler improvements:**

- Documented and clarified that `currentBattle` is a singleton, shared across all transports, so a battle started in one client is visible to others.

- Enhanced tool handler documentation and added comments to clarify the responsibilities and flow of each tool, including new and existing handlers for Pokemon operations and battle mechanics. [[1]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R392) [[2]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R423) [[3]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R433) [[4]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R480) [[5]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R571) [[6]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R586)

**Dependency and documentation updates:**

- Upgraded the `@modelcontextprotocol/sdk` dependency from version `^0.4.0` to `^1.26.0` in `package.json` to support new transport features.

- Updated the `README.md` to clarify the need for an actual server using stdio for MCP client testing.